### PR TITLE
registering language server via python entry_points

### DIFF
--- a/ipython_magic/sparksql/main.py
+++ b/ipython_magic/sparksql/main.py
@@ -1,10 +1,12 @@
+import logging
 import pathlib
 import shutil
 import subprocess
 import sys
-import logging
+
 from jupyter_lsp.specs.config import load_config_schema
 from jupyter_lsp.types import LanguageServerManagerAPI
+
 
 NODE_LOCATION = (
     shutil.which("node") or
@@ -25,15 +27,14 @@ SCRIPTS = ["dist", "bin", "cli.js"]
 PATH_TO_BIN_JS = mgr.find_node_module(NODE_MODULE, *SCRIPTS)
 
 
-
 def main():
     logging.info(NODE)
     logging.info(PATH_TO_BIN_JS)
-    p = subprocess.Popen(
+    process = subprocess.Popen(
         [NODE, PATH_TO_BIN_JS, *sys.argv[1:]],
         stdin=sys.stdin, stdout=sys.stdout
     )
-    sys.exit(p.wait())
+    sys.exit(process.wait())
 
 
 def load(app):

--- a/ipython_magic/sparksql/main.py
+++ b/ipython_magic/sparksql/main.py
@@ -1,0 +1,57 @@
+import pathlib
+import shutil
+import subprocess
+import sys
+import logging
+from jupyter_lsp.specs.config import load_config_schema
+from jupyter_lsp.types import LanguageServerManagerAPI
+
+NODE_LOCATION = (
+    shutil.which("node") or
+    shutil.which("node.exe") or
+    shutil.which("node.cmd")
+)
+NODE = str(pathlib.Path(NODE_LOCATION).resolve())
+
+
+mgr = LanguageServerManagerAPI()
+
+# If jupyterlab-lsp has difficulty finding your sql-language-server
+# installation, specify additional node_modules paths
+mgr.extra_node_roots = ["/usr/local/lib/"]
+
+NODE_MODULE = KEY = "sql-language-server"
+SCRIPTS = ["dist", "bin", "cli.js"]
+PATH_TO_BIN_JS = mgr.find_node_module(NODE_MODULE, *SCRIPTS)
+
+
+
+def main():
+    logging.info(NODE)
+    logging.info(PATH_TO_BIN_JS)
+    p = subprocess.Popen(
+        [NODE, PATH_TO_BIN_JS, *sys.argv[1:]],
+        stdin=sys.stdin, stdout=sys.stdout
+    )
+    sys.exit(p.wait())
+
+
+def load(app):
+    logging.info(NODE)
+    logging.info(PATH_TO_BIN_JS)
+    return {
+        "sparksql-language-server": {
+            "version": 2,
+            "argv": ["sparksql_language_server", "up", "--method", "stdio"],
+            "languages": ["sparksql"],
+            "display_name": "Spark language server",
+            "mime_types": [
+                "application/sparksql", "application/x-sparksql"
+            ],
+            "config_schema": load_config_schema(KEY),
+        }
+    }
+
+
+if __name__ == "__main__":
+    main()

--- a/ipython_magic/trino/main.py
+++ b/ipython_magic/trino/main.py
@@ -1,10 +1,12 @@
+import logging
 import pathlib
 import shutil
 import subprocess
 import sys
-import logging
+
 from jupyter_lsp.specs.config import load_config_schema
 from jupyter_lsp.types import LanguageServerManagerAPI
+
 
 NODE_LOCATION = (
     shutil.which("node") or
@@ -12,10 +14,14 @@ NODE_LOCATION = (
     shutil.which("node.cmd")
 )
 NODE = str(pathlib.Path(NODE_LOCATION).resolve())
+
+
 mgr = LanguageServerManagerAPI()
+
 # If jupyterlab-lsp has difficulty finding your sql-language-server
 # installation, specify additional node_modules paths
 mgr.extra_node_roots = ["/usr/local/lib/"]
+
 NODE_MODULE = KEY = "sql-language-server"
 SCRIPTS = ["dist", "bin", "cli.js"]
 PATH_TO_BIN_JS = mgr.find_node_module(NODE_MODULE, *SCRIPTS)
@@ -24,11 +30,11 @@ PATH_TO_BIN_JS = mgr.find_node_module(NODE_MODULE, *SCRIPTS)
 def main():
     logging.info(NODE)
     logging.info(PATH_TO_BIN_JS)
-    p = subprocess.Popen(
+    process = subprocess.Popen(
         [NODE, PATH_TO_BIN_JS, *sys.argv[1:]],
         stdin=sys.stdin, stdout=sys.stdout
     )
-    sys.exit(p.wait())
+    sys.exit(process.wait())
 
 
 def load(app):

--- a/ipython_magic/trino/main.py
+++ b/ipython_magic/trino/main.py
@@ -1,0 +1,52 @@
+import pathlib
+import shutil
+import subprocess
+import sys
+import logging
+from jupyter_lsp.specs.config import load_config_schema
+from jupyter_lsp.types import LanguageServerManagerAPI
+
+NODE_LOCATION = (
+    shutil.which("node") or
+    shutil.which("node.exe") or
+    shutil.which("node.cmd")
+)
+NODE = str(pathlib.Path(NODE_LOCATION).resolve())
+mgr = LanguageServerManagerAPI()
+# If jupyterlab-lsp has difficulty finding your sql-language-server
+# installation, specify additional node_modules paths
+mgr.extra_node_roots = ["/usr/local/lib/"]
+NODE_MODULE = KEY = "sql-language-server"
+SCRIPTS = ["dist", "bin", "cli.js"]
+PATH_TO_BIN_JS = mgr.find_node_module(NODE_MODULE, *SCRIPTS)
+
+
+def main():
+    logging.info(NODE)
+    logging.info(PATH_TO_BIN_JS)
+    p = subprocess.Popen(
+        [NODE, PATH_TO_BIN_JS, *sys.argv[1:]],
+        stdin=sys.stdin, stdout=sys.stdout
+    )
+    sys.exit(p.wait())
+
+
+def load(app):
+    logging.info(NODE)
+    logging.info(PATH_TO_BIN_JS)
+    return {
+        "trino-language-server": {
+            "version": 2,
+            "argv": ["trino_language_server", "up", "--method", "stdio"],
+            "languages": ["trino"],
+            "display_name": "Trino language server",
+            "mime_types": [
+                "application/trino", "application/x-trino"
+            ],
+            "config_schema": load_config_schema(KEY),
+        }
+    }
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,16 @@ setup_args = dict(
         "Framework :: Jupyter :: JupyterLab :: Extensions",
         "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
     ],
+    entry_points={
+        "console_scripts": [
+            "sparksql_language_server = ipython_magic.sparksql.main:main",
+            "trino_language_server = ipython_magic.trino.main:main",
+        ],
+        "jupyter_lsp_spec_v1": [
+            "trino-language-server = ipython_magic.trino.main:load",
+            "sparksql-language-server = ipython_magic.sparksql.main:load",
+        ],
+    },
 )
 
 try:


### PR DESCRIPTION
this removes the need for an external configuration file to register

the language specifications