### PR TITLE
module name jupyterlab_sql_editor missing when %load_ext in example SparkSQLEscapeControlChars.ipynb

### DIFF
--- a/example/SparkSQLEscapeControlChars.ipynb
+++ b/example/SparkSQLEscapeControlChars.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "spark = SparkSession.builder.getOrCreate()\n",
     "\n",
-    "%load_ext ipython_magic.sparksql"
+    "%load_ext jupyterlab_sql_editor.ipython_magic.sparksql"
    ]
   },
   {


### PR DESCRIPTION
Module name `jupyterlab_sql_editor` missing when `%load_ext` in example `SparkSQLEscapeControlChars.ipynb`