### PR TITLE
Casting Spark results to string for json display

### DIFF
--- a/jupyterlab_sql_editor/ipython/sparkdf.py
+++ b/jupyterlab_sql_editor/ipython/sparkdf.py
@@ -56,7 +56,11 @@ def display_spark_df(df, output, limit, truncate, show_nonprinting):
         has_more_data, pdf = to_pandas(df, limit, truncate, show_nonprinting)
         displays.append(render_grid(pdf, limit))
     elif output == "json":
-        results = df.select(F.to_json(F.struct(F.col("*"))).alias("json_str")).take(limit + 1)
+        results = (
+            df.select([F.col(c).cast("string") for c in df.columns])
+            .select(F.to_json(F.struct(F.col("*"))).alias("json_str"))
+            .take(limit + 1)
+        )
         if len(results) > limit:
             has_more_data = True
         json_array = [json.loads(r.json_str) for r in results[:limit]]

--- a/jupyterlab_sql_editor/ipython_magic/common/base.py
+++ b/jupyterlab_sql_editor/ipython_magic/common/base.py
@@ -81,6 +81,9 @@ class Base(Magics):
         super().__init__(shell, **kwargs)
         self.user_ns = {}
 
+    def display_results():
+        pass
+
     @staticmethod
     def bind_variables(query, user_ns):
         template = Template(query, undefined=ExplainUndefined)
@@ -109,18 +112,18 @@ class Base(Magics):
         self.user_ns = self.shell.user_ns.copy()
         self.user_ns.update(local_ns)
 
-    @staticmethod
-    def should_update_schema(schema_file_name, refresh_threshold):
-        file_exists = os.path.isfile(schema_file_name)
-        ttl_expired = False
-        if file_exists:
-            file_time = os.path.getmtime(schema_file_name)
-            current_time = time.time()
-            if current_time - file_time > (refresh_threshold * 60):
-                print(f"TTL {refresh_threshold} minutes expired, re-generating schema file: {schema_file_name}")
-                ttl_expired = True
+    # @staticmethod
+    # def should_update_schema(schema_file_name, refresh_threshold):
+    #     file_exists = os.path.isfile(schema_file_name)
+    #     ttl_expired = False
+    #     if file_exists:
+    #         file_time = os.path.getmtime(schema_file_name)
+    #         current_time = time.time()
+    #         if current_time - file_time > (refresh_threshold * 60):
+    #             print(f"TTL {refresh_threshold} minutes expired, re-generating schema file: {schema_file_name}")
+    #             ttl_expired = True
 
-        return (not file_exists) or ttl_expired
+    #     return (not file_exists) or ttl_expired
 
     def display_sql(self, sql):
         def _jupyterlab_repr_html_(self):

--- a/jupyterlab_sql_editor/ipython_magic/common/base.py
+++ b/jupyterlab_sql_editor/ipython_magic/common/base.py
@@ -112,18 +112,18 @@ class Base(Magics):
         self.user_ns = self.shell.user_ns.copy()
         self.user_ns.update(local_ns)
 
-    # @staticmethod
-    # def should_update_schema(schema_file_name, refresh_threshold):
-    #     file_exists = os.path.isfile(schema_file_name)
-    #     ttl_expired = False
-    #     if file_exists:
-    #         file_time = os.path.getmtime(schema_file_name)
-    #         current_time = time.time()
-    #         if current_time - file_time > (refresh_threshold * 60):
-    #             print(f"TTL {refresh_threshold} minutes expired, re-generating schema file: {schema_file_name}")
-    #             ttl_expired = True
+    @staticmethod
+    def should_update_schema(schema_file_name, refresh_threshold):
+        file_exists = os.path.isfile(schema_file_name)
+        ttl_expired = False
+        if file_exists:
+            file_time = os.path.getmtime(schema_file_name)
+            current_time = time.time()
+            if current_time - file_time > (refresh_threshold * 60):
+                print(f"TTL {refresh_threshold} minutes expired, re-generating schema file: {schema_file_name}")
+                ttl_expired = True
 
-    #     return (not file_exists) or ttl_expired
+        return (not file_exists) or ttl_expired
 
     def display_sql(self, sql):
         def _jupyterlab_repr_html_(self):

--- a/jupyterlab_sql_editor/ipython_magic/sparksql/sparksql.py
+++ b/jupyterlab_sql_editor/ipython_magic/sparksql/sparksql.py
@@ -172,9 +172,12 @@ class SparkSql(Base):
             if args.eager:
                 results.count()
 
+        if args.dataframe:
+            print(f"Captured dataframe to local variable `{args.dataframe}`")
+            self.shell.user_ns.update({args.dataframe: results})
+
         self.display_results(
             results=results,
-            dataframe=args.dataframe,
             output=output,
             limit=limit,
             truncate=truncate,
@@ -219,7 +222,6 @@ class SparkSql(Base):
     def display_results(
         self,
         results,
-        dataframe,
         output="grid",
         limit=20,
         truncate=512,
@@ -228,10 +230,6 @@ class SparkSql(Base):
         sql=None,
         streaming_mode="update",
     ):
-        if dataframe:
-            print(f"Captured dataframe to local variable `{dataframe}`")
-            self.shell.user_ns.update({dataframe: results})
-
         # TODO: Revisit this
         display_df(
             df=results,

--- a/jupyterlab_sql_editor/ipython_magic/sparksql/sparksql.py
+++ b/jupyterlab_sql_editor/ipython_magic/sparksql/sparksql.py
@@ -116,6 +116,10 @@ class SparkSql(Base):
         if args.truncate and args.truncate > 0:
             truncate = args.truncate
 
+        limit = args.limit
+        if limit is None:
+            limit = self.limit
+
         if output not in VALID_OUTPUTS:
             print(f"Invalid output option {args.output}. The valid options are [sql|json|text|html|grid|skip|none].")
             return
@@ -148,7 +152,7 @@ class SparkSql(Base):
         # we treat these use cases differently than a SELECT that returns rows of data
         start = time()
         try:
-            result = self.spark.sql(sql)
+            results = self.spark.sql(sql)
         except PYSPARK_ERROR_TYPES as exc:
             if args.lean_exceptions:
                 self.print_pyspark_error(exc)
@@ -156,7 +160,7 @@ class SparkSql(Base):
             else:
                 raise exc
         end = time()
-        if len(result.columns) == 0:
+        if len(results.columns) == 0:
             elapsed = end - start
             print(f"Execution time: {elapsed:.2f} seconds")
             return
@@ -164,20 +168,13 @@ class SparkSql(Base):
         if args.cache or args.eager:
             load_type = "eager" if args.eager else "lazy"
             print(f"Cached dataframe with {load_type} load")
-            result = result.cache()
+            results = results.cache()
             if args.eager:
-                result.count()
+                results.count()
 
-        if args.dataframe:
-            print(f"Captured dataframe to local variable `{args.dataframe}`")
-            self.shell.user_ns.update({args.dataframe: result})
-
-        limit = args.limit
-        if limit is None:
-            limit = self.limit
-
-        display_df(
-            result,
+        self.display_results(
+            results=results,
+            dataframe=args.dataframe,
             output=output,
             limit=limit,
             truncate=truncate,
@@ -218,6 +215,34 @@ class SparkSql(Base):
     @staticmethod
     def get_instantiated_spark_session():
         return SparkSession._instantiatedSession
+
+    def display_results(
+        self,
+        results,
+        dataframe,
+        output="grid",
+        limit=20,
+        truncate=512,
+        show_nonprinting=False,
+        query_name=None,
+        sql=None,
+        streaming_mode="update",
+    ):
+        if dataframe:
+            print(f"Captured dataframe to local variable `{dataframe}`")
+            self.shell.user_ns.update({dataframe: results})
+
+        # TODO: Revisit this
+        display_df(
+            df=results,
+            output=output,
+            limit=limit,
+            truncate=truncate,
+            show_nonprinting=show_nonprinting,
+            query_name=query_name,
+            sql=sql,
+            streaming_mode=streaming_mode,
+        )
 
     def get_dbt_sql_statement(self, cell, sql_argument):
         sql = cell

--- a/jupyterlab_sql_editor/ipython_magic/trino/trino.py
+++ b/jupyterlab_sql_editor/ipython_magic/trino/trino.py
@@ -161,21 +161,20 @@ class Trino(Base):
 
         results = list(map(lambda row: [self.format_cell(v, output, truncate) for v in row], results[:limit]))
 
+        if args.dataframe:
+            print(f"Saved results to pandas dataframe named `{args.dataframe}`")
+            pdf = pd.DataFrame.from_records(results, columns=columns)
+            self.shell.user_ns.update({args.dataframe: pdf})
+
         self.display_results(
             results=results,
-            dataframe=args.dataframe,
             columns=columns,
             output=output,
             limit=limit,
             show_nonprinting=args.show_nonprinting,
         )
 
-    def display_results(self, results, dataframe, columns, output, limit=20, show_nonprinting=False):
-        if dataframe:
-            print(f"Saved results to pandas dataframe named `{dataframe}`")
-            pdf = pd.DataFrame.from_records(results, columns=columns)
-            self.shell.user_ns.update({dataframe: pdf})
-
+    def display_results(self, results, columns, output, limit=20, show_nonprinting=False):
         if output == "grid":
             pdf = pd.DataFrame.from_records(results, columns=columns)
             if show_nonprinting:


### PR DESCRIPTION
Reorganized the code a tiny bit. Now casting the spark dataframe results to string before converting to a json string for the display of data in a json structure. Avoids longs getting rounded and other potential future issues when converting to json at the cost of casting the results to string before displaying them.