### PR TITLE
casting fn changes

### DIFF
--- a/jupyterlab_sql_editor/ipython/common.py
+++ b/jupyterlab_sql_editor/ipython/common.py
@@ -12,6 +12,10 @@ PRINTABLE = string.ascii_letters + string.digits + string.punctuation + " "
 
 replchars = re.compile("([^" + re.escape(PRINTABLE) + "])")
 
+JS_MAX_SAFE_INTEGER = 9007199254740991
+
+JS_MIN_SAFE_INTEGER = -9007199254740991
+
 
 def make_tag(tag_name, show_nonprinting, body="", **kwargs):
     body = str(body)
@@ -102,3 +106,25 @@ def find_nvm_lib_dirs():
             if isdir(join(nvm_dir + NVM_VERSIONS_SUBPATH, d))
         ]
     return dirs
+
+
+def cast_unsafe_ints_to_str(data, warnings=[]):
+    result = dict()
+
+    if isinstance(data, dict):
+        for key, value in data.items():
+            result[key] = cast_unsafe_ints_to_str(value, warnings)
+    elif isinstance(data, list):
+        json_array = []
+        for v in data:
+            json_array.append(cast_unsafe_ints_to_str(v, warnings))
+        return json_array
+    elif isinstance(data, int):
+        if data <= JS_MAX_SAFE_INTEGER and data >= JS_MIN_SAFE_INTEGER:
+            return data
+        else:
+            warnings.append(f"int {data} was cast to string to avoid loss of precision.")
+            return str(data)
+    else:
+        return data
+    return result

--- a/jupyterlab_sql_editor/ipython_magic/sparksql/sparksql.py
+++ b/jupyterlab_sql_editor/ipython_magic/sparksql/sparksql.py
@@ -103,6 +103,7 @@ class SparkSql(Base):
         action="store_true",
         help="Shortened exceptions. Might be helpful if the exceptions reported by Spark are noisy such as with big SQL queries",
     )
+    @argument("--expand", action="store_true", help="Expand json results")
     def sparksql(self, line=None, cell=None, local_ns=None):
         "Magic that works both as %sparksql and as %%sparksql"
         self.set_user_ns(local_ns)
@@ -185,6 +186,7 @@ class SparkSql(Base):
             query_name=args.view,
             sql=sql,
             streaming_mode=streaming_mode,
+            args=args,
         )
 
     def check_refresh(self, refresh_arg, output_file, catalog_array):
@@ -229,6 +231,7 @@ class SparkSql(Base):
         query_name=None,
         sql=None,
         streaming_mode="update",
+        args=None,
     ):
         # TODO: Revisit this
         display_df(
@@ -240,6 +243,7 @@ class SparkSql(Base):
             query_name=query_name,
             sql=sql,
             streaming_mode=streaming_mode,
+            args=args,
         )
 
     def get_dbt_sql_statement(self, cell, sql_argument):

--- a/jupyterlab_sql_editor/ipython_magic/trino/trino.py
+++ b/jupyterlab_sql_editor/ipython_magic/trino/trino.py
@@ -193,8 +193,8 @@ class Trino(Base):
             for row in json_dict:
                 json_array.append(cast_unsafe_ints_to_str(row, warnings))
             if show_nonprinting:
-                recursive_escape(json_dict)
-            display(warnings, JSON(json_dict, expanded=args.expand))
+                recursive_escape(json_array)
+            display(warnings, JSON(json_array, expanded=args.expand))
         elif output == "html":
             html = rows_to_html(columns, results, show_nonprinting)
             display(HTML(make_tag("table", False, html)))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-sql-editor",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "description": "SQL editor support for formatting, syntax highlighting and code completion of SQL in cell magic, line magic, python string and file editor.",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-sql-editor",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "description": "SQL editor support for formatting, syntax highlighting and code completion of SQL in cell magic, line magic, python string and file editor.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
- Reworked the casting to string to only cast unsafe JS ints as they're the only data type with precision issues when being sent to the React front-end. 
- Make Trino use the same code
- Allow users to auto-expand the json output