### PR TITLE
Implements the json_cmt flag for Trino

### DIFF
--- a/jupyterlab_sql_editor/ipython/sparkdf.py
+++ b/jupyterlab_sql_editor/ipython/sparkdf.py
@@ -13,12 +13,12 @@ from pyspark.sql.session import SparkSession
 
 import jupyterlab_sql_editor.ipython.spark_streaming_query as streaming
 from jupyterlab_sql_editor.ipython.common import (
-    cast_unsafe_ints_to_str,
     escape_control_chars,
     recursive_escape,
     render_ag_grid,
     render_grid,
     rows_to_html,
+    sanitize_results,
 )
 from jupyterlab_sql_editor.ipython.SparkSchemaWidget import SparkSchemaWidget
 
@@ -63,11 +63,11 @@ def display_spark_df(df, output, limit, truncate, show_nonprinting, args):
         json_array = []
         warnings = []
         results = df.toJSON().map(lambda j: json.loads(j)).take(limit)
-        if df.count() > limit:
+        if len(results) > limit:
             has_more_data = True
         # cast unsafe ints to str for display
         for row in results:
-            json_array.append(cast_unsafe_ints_to_str(row, warnings))
+            json_array.append(sanitize_results(row, warnings))
         # add warnings to displays
         for warning in warnings:
             displays.append(warning)

--- a/jupyterlab_sql_editor/ipython_magic/trino/trino.py
+++ b/jupyterlab_sql_editor/ipython_magic/trino/trino.py
@@ -13,7 +13,6 @@ from jupyterlab_sql_editor.ipython.common import (
     escape_control_chars,
     make_tag,
     recursive_escape,
-    render_ag_grid,
     render_grid,
     rows_to_html,
 )
@@ -22,7 +21,7 @@ from jupyterlab_sql_editor.ipython_magic.trino.trino_export import (
     update_database_schema,
 )
 
-VALID_OUTPUTS = ["sql", "text", "json", "html", "aggrid", "grid", "skip", "none"]
+VALID_OUTPUTS = ["sql", "text", "json", "json_cmt", "html", "grid", "skip", "none"]
 
 
 @magics_class
@@ -75,7 +74,7 @@ class Trino(Base):
     @argument(
         "-o",
         "--output",
-        metavar="sql|json|html|aggrid|grid|text|skip|none",
+        metavar="sql|json|json_cmt|html|aggrid|grid|text|skip|none",
         type=str,
         default="html",
         help="Output format. Defaults to html. The `sql` option prints the SQL statement that will be executed (useful to test jinja templated statements)",
@@ -178,6 +177,19 @@ class Trino(Base):
             args=args,
         )
 
+    def __convert_dictionary(self, value):
+        # If it's a list, go in each element as they could be of some other type, and continue processing it
+        if type(value) is list:
+            return [self.__convert_dictionary(element) for element in value]
+        # If it's a NamedRowTuple (weird Trino tuple), create a dictionary, extract the name from the NRT as the key, and process value
+        elif type(value) is trino.client.NamedRowTuple:
+            temp_dict = {}
+            for kk, v in zip(value._names, value):
+                temp_dict[kk] = self.__convert_dictionary(v)
+            return temp_dict
+        else:
+            return value
+
     def display_results(self, results, columns, output, limit=20, show_nonprinting=False, args=None):
         if output == "grid":
             pdf = pd.DataFrame.from_records(results, columns=columns)
@@ -185,17 +197,51 @@ class Trino(Base):
                 for c in pdf.columns:
                     pdf[c] = pdf[c].apply(lambda v: escape_control_chars(str(v)))
             display(render_grid(pdf, limit))
-        elif output == "aggrid":
-            pdf = pd.DataFrame.from_records(results, columns=columns)
-            if show_nonprinting:
-                for c in pdf.columns:
-                    pdf[c] = pdf[c].apply(lambda v: escape_control_chars(str(v)))
-            display(render_ag_grid(pdf))
         elif output == "json":
             json_array = []
             warnings = []
             json_string = pd.DataFrame.from_records(results, columns=columns).to_json(orient="records")
             json_dict = json.loads(json_string)
+            # cast unsafe ints to str for display
+            for row in json_dict:
+                json_array.append(cast_unsafe_ints_to_str(row, warnings))
+            if show_nonprinting:
+                recursive_escape(json_array)
+            display(warnings, JSON(json_array, expanded=args.expand))
+        elif output == "json_cmt":
+            json_array = []
+            warnings = []
+            json_string = pd.DataFrame.from_records(results, columns=columns).to_json(orient="records")
+            json_dict = json.loads(json_string)
+
+            # Returns this list which should contain the dictionaries (rows) of the query
+            my_dictionary_list = []
+            # Iterate through the rows returned (json_dict {list}) and process the columns
+            for row_index, dictionary_entries in enumerate(json_dict):
+                # Goes through each column for a given row, checks the type, and processes them into a dictionary
+                current_row_as_dictionary = {}
+                for (
+                    column_index,
+                    top_level_column,
+                ) in enumerate(dictionary_entries.keys()):
+                    # results[row_index][column_index] returns the row and current column's values. The key or column name
+                    # is found in the top_level_column value within the loop
+                    # We are essentially pairing up the values from the raw "results" variable passed to us with the column
+                    # names that we can extract from the pandas dataframe
+                    if type(results[row_index][column_index]) is list:
+                        current_row_as_dictionary[top_level_column] = [
+                            self.__convert_dictionary(element) for element in results[row_index][column_index]
+                        ]
+                    elif type(results[row_index][column_index]) is trino.client.NamedRowTuple:
+                        current_row_as_dictionary[top_level_column] = self.__convert_dictionary(
+                            results[row_index][column_index]
+                        )
+                    else:
+                        current_row_as_dictionary[top_level_column] = results[row_index][column_index]
+                my_dictionary_list.append(current_row_as_dictionary)
+            # Sets the new reconstructed dictionary rows to json_dict because I don't want to change the variable reference
+            json_dict = my_dictionary_list
+
             # cast unsafe ints to str for display
             for row in json_dict:
                 json_array.append(cast_unsafe_ints_to_str(row, warnings))
@@ -218,7 +264,7 @@ class Trino(Base):
 
     @staticmethod
     def format_cell(v, output="html", truncate=256):
-        if output != "json" and isinstance(v, str):
+        if output != "json" and output != "json_cmt" and isinstance(v, str):
             if len(v) > truncate:
                 v = v[:truncate] + "..."
         return v

--- a/jupyterlab_sql_editor/ipython_magic/trino/trino.py
+++ b/jupyterlab_sql_editor/ipython_magic/trino/trino.py
@@ -218,8 +218,7 @@ class Trino(Base):
         elif output == "json_cmt":
             json_array = []
             warnings = []
-            json_string = pd.DataFrame.from_records(results, columns=columns).to_json(orient="records")
-            json_dict = json.loads(json_string)
+            json_dict = pd.DataFrame.from_records(results, columns=columns).to_dict(orient="records")
 
             # Returns this list which should contain the dictionaries (rows) of the query
             my_dictionary_list = []
@@ -235,16 +234,7 @@ class Trino(Base):
                     # is found in the top_level_column value within the loop
                     # We are essentially pairing up the values from the raw "results" variable passed to us with the column
                     # names that we can extract from the pandas dataframe
-                    if type(results[row_index][column_index]) is list:
-                        current_row_as_dictionary[top_level_column] = [
-                            self.__convert_dictionary(element) for element in results[row_index][column_index]
-                        ]
-                    elif type(results[row_index][column_index]) is trino.client.NamedRowTuple:
-                        current_row_as_dictionary[top_level_column] = self.__convert_dictionary(
-                            results[row_index][column_index]
-                        )
-                    else:
-                        current_row_as_dictionary[top_level_column] = results[row_index][column_index]
+                    current_row_as_dictionary[top_level_column] = self.__convert_dictionary(results[row_index][column_index])
                 my_dictionary_list.append(current_row_as_dictionary)
             # Sets the new reconstructed dictionary rows to json_dict because I don't want to change the variable reference
             # The loading and dumping will convert DateTime objects to something JSON serializable
@@ -337,3 +327,4 @@ class Trino(Base):
         link = "http://localhost"
         app_name = "name"
         display(HTML(f"""<a class="external" href="{link}" target="_blank" >Open Spark UI ⭐ {app_name}</a>"""))
+

--- a/jupyterlab_sql_editor/ipython_magic/trino/trino.py
+++ b/jupyterlab_sql_editor/ipython_magic/trino/trino.py
@@ -180,10 +180,10 @@ class Trino(Base):
 
     def __convert_dictionary(self, value):
         # If it's a list, go in each element as they could be of some other type, and continue processing it
-        if type(value) is list:
+        if isinstance(value, list):
             return [self.__convert_dictionary(element) for element in value]
         # If it's a NamedRowTuple (weird Trino tuple), create a dictionary, extract the name from the NRT as the key, and process value
-        elif type(value) is trino.client.NamedRowTuple:
+        elif isinstance(value, trino.client.NamedRowTuple):
             temp_dict = {}
             for kk, v in zip(value._names, value):
                 temp_dict[kk] = self.__convert_dictionary(v)

--- a/jupyterlab_sql_editor/ipython_magic/trino/trino.py
+++ b/jupyterlab_sql_editor/ipython_magic/trino/trino.py
@@ -247,7 +247,8 @@ class Trino(Base):
                         current_row_as_dictionary[top_level_column] = results[row_index][column_index]
                 my_dictionary_list.append(current_row_as_dictionary)
             # Sets the new reconstructed dictionary rows to json_dict because I don't want to change the variable reference
-            json_dict = my_dictionary_list
+            # The loading and dumping will convert DateTime objects to something JSON serializable
+            json_dict = json.loads(json.dumps(my_dictionary_list, indent=4, sort_keys=True, default=str))
 
             # cast unsafe ints to str for display
             for row in json_dict:

--- a/jupyterlab_sql_editor/ipython_magic/trino/trino.py
+++ b/jupyterlab_sql_editor/ipython_magic/trino/trino.py
@@ -13,6 +13,7 @@ from jupyterlab_sql_editor.ipython.common import (
     escape_control_chars,
     make_tag,
     recursive_escape,
+    render_ag_grid,
     render_grid,
     rows_to_html,
 )
@@ -21,7 +22,7 @@ from jupyterlab_sql_editor.ipython_magic.trino.trino_export import (
     update_database_schema,
 )
 
-VALID_OUTPUTS = ["sql", "text", "json", "json_cmt", "html", "grid", "skip", "none"]
+VALID_OUTPUTS = ["sql", "text", "json", "json_cmt", "html", "aggrid", "grid", "skip", "none"]
 
 
 @magics_class
@@ -197,6 +198,12 @@ class Trino(Base):
                 for c in pdf.columns:
                     pdf[c] = pdf[c].apply(lambda v: escape_control_chars(str(v)))
             display(render_grid(pdf, limit))
+        elif output == "aggrid":
+            pdf = pd.DataFrame.from_records(results, columns=columns)
+            if show_nonprinting:
+                for c in pdf.columns:
+                    pdf[c] = pdf[c].apply(lambda v: escape_control_chars(str(v)))
+            display(render_ag_grid(pdf))
         elif output == "json":
             json_array = []
             warnings = []

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-sql-editor",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "description": "SQL editor support for formatting, syntax highlighting and code completion of SQL in cell magic, line magic, python string and file editor.",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-sql-editor",
-  "version": "0.1.66",
+  "version": "0.1.67-alpha.1",
   "description": "SQL editor support for formatting, syntax highlighting and code completion of SQL in cell magic, line magic, python string and file editor.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
This allows the Trino magic to output nested structures with their proper column names instead of turning it into an array which loses information.

**This also removes the aggrid output to reflect production**

For example, the fix now outputs this:
```
col1: "some value"
col2: "other value"
nested_col:  (type: dictionary)
   struct_val1: "hey"
   struct_val2: "works"
col3: "top level value"
```

whereas the current -o json flag does this:
```
col1: "some value"
col2: "other value"
nested_col:  (type: array)
   0: "hey"
   1: "works"
col3: "top level value"
```