### PR TITLE
better timestamp formatting

### DIFF
--- a/jupyterlab_sql_editor/outputters/outputters.py
+++ b/jupyterlab_sql_editor/outputters/outputters.py
@@ -82,9 +82,9 @@ def jjson(df: pd.DataFrame, show_nonprinting=False, expanded=False, date_format=
 
 
 def html(df: pd.DataFrame, show_nonprinting=False, truncate=256) -> None:
-    html = rows_to_html(sanitize_results(df.values.tolist()), df.columns.values.tolist(), show_nonprinting, truncate)
+    html = rows_to_html(sanitize_results(df.to_numpy()), df.columns.values.tolist(), show_nonprinting, truncate)
     display(HTML(make_tag("table", False, html)))
 
 
 def text(df: pd.DataFrame, truncate=256) -> None:
-    print(render_text(sanitize_results(df.values.tolist()), df.columns.values.tolist(), truncate))
+    print(render_text(sanitize_results(df.to_numpy()), df.columns.values.tolist(), truncate))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-sql-editor",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "description": "SQL editor support for formatting, syntax highlighting and code completion of SQL in cell magic, line magic, python string and file editor.",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-sql-editor",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "description": "SQL editor support for formatting, syntax highlighting and code completion of SQL in cell magic, line magic, python string and file editor.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Improving the timestamp formatting for every other output other than json. numpy datetimes would convert to integers when .tolist() was used on the numpy array. Now we convert the numpy datetimes to pandas datetimes since it converts and prints out nicely afterwards. Also fixed some oversights for json int to string casting