### PR TITLE
human readable dates for text & html outputs

### DIFF
--- a/jupyterlab_sql_editor/outputters/outputters.py
+++ b/jupyterlab_sql_editor/outputters/outputters.py
@@ -6,6 +6,7 @@ import pandas as pd
 from IPython.display import HTML, JSON, display
 
 from jupyterlab_sql_editor.outputters.util import (
+    dataframe_conditional_conversion,
     format_value,
     make_tag,
     recursive_escape,
@@ -83,10 +84,17 @@ def jjson(df: pd.DataFrame, show_nonprinting=False, expanded=False, date_format=
 
 def html(df: pd.DataFrame, show_nonprinting=False, truncate=256) -> None:
     html = rows_to_html(
-        sanitize_results(df.to_numpy(dtype=object)), df.columns.values.tolist(), show_nonprinting, truncate
+        sanitize_results(df.apply(dataframe_conditional_conversion).values),
+        df.columns.values.tolist(),
+        show_nonprinting,
+        truncate,
     )
     display(HTML(make_tag("table", False, html)))
 
 
 def text(df: pd.DataFrame, truncate=256) -> None:
-    print(render_text(sanitize_results(df.to_numpy(dtype=object)), df.columns.values.tolist(), truncate))
+    print(
+        render_text(
+            sanitize_results(df.apply(dataframe_conditional_conversion).values), df.columns.values.tolist(), truncate
+        )
+    )

--- a/jupyterlab_sql_editor/outputters/util.py
+++ b/jupyterlab_sql_editor/outputters/util.py
@@ -761,3 +761,12 @@ def format_value(text, show_nonprinting=False, truncate=0):
         if truncate > 0 and len(formatted_value) > truncate:
             formatted_value = formatted_value[:truncate] + "..."
     return formatted_value
+
+
+# Define a function for conditional conversion of a Pandas df column
+# Allows us to have human readable dates & avoid issues like ints
+# being cast to something with decimals
+def dataframe_conditional_conversion(col):
+    if pd.api.types.is_datetime64_any_dtype(col):
+        return col.values.astype("datetime64[ns]")
+    return col.values.astype(object)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-sql-editor",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "SQL editor support for formatting, syntax highlighting and code completion of SQL in cell magic, line magic, python string and file editor.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Conditional conversion of Pandas df columns to allow us to have human readable dates & avoid issues like ints being cast to something with decimals at the same time. This is specific to the text and html outputs.